### PR TITLE
Add CRC check to readout (currently not hot)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 CFLAGS=-m32 -Wall -Werror
+HEADERS=$(wildcard *.h)
 
 test: crc8.o test.o
 	gcc $(CFLAGS) -o test $^
 
-%.o: %.c
+%.o: %.c $(HEADERS)
 	gcc $(CFLAGS) -c $<


### PR DESCRIPTION
The CRC check is applied when reading the scratchpad memory, however, it is not enforced yet (read temperature as well as the main loop treat ONEWIRE_CRC_ERROR return code as success).

If this turns out to be working nicely, a different handling could be used, such as re-trying the readout one or two times and/or notifying the tempd.
