### PR TITLE
Reject invalid sensor IDs and readouts based on CRC check

### DIFF
--- a/test.c
+++ b/test.c
@@ -369,16 +369,19 @@ int main(int argc, char **argv)
         while (onewire_findnext(fd, addr) == ONEWIRE_PRESENCE) {
             onewire_ds18b20_invoke_conversion(fd, addr);
             sleep(4);
-            int16_t raw;
-            uint8_t status = onewire_ds18b20_read_temperature_retry(fd, addr, &raw, 2);
-            if (status != ONEWIRE_PRESENCE) {
-                fprintf(stderr, "read failed\n");
-                sleep(1);
-                continue;
-            }
 
             for (unsigned i = 0; i < UART_1W_ADDR_LEN; ++i) {
                 printf("%02x", addr[i]);
+            }
+
+            int16_t raw;
+            uint8_t status = onewire_ds18b20_read_temperature_retry(fd, addr, &raw, 2);
+            if (status != ONEWIRE_PRESENCE) {
+                printf(" read failed (reason=0x%02x)\n",
+                       status);
+                fprintf(stderr, "read failed\n");
+                sleep(1);
+                continue;
             }
 
             printf(" %f\n", (float)raw/16.0);

--- a/test.c
+++ b/test.c
@@ -246,6 +246,13 @@ int onewire_findnext(int fd, onewire_addr_t addr)
 
     }
 
+    crc8_state_t state;
+    crc8_init(&state, 0x31);
+    if (crc8_feed(&state, (const char *)&addr[0], UART_1W_ADDR_LEN) != 0) {
+        fprintf(stderr, "crc error while finding device\n");
+        return ONEWIRE_CRC_ERROR;
+    }
+
     return ONEWIRE_PRESENCE;
 }
 


### PR DESCRIPTION
This rejects misread sensor IDs and temperature readouts based on the CRC check.

Future work: re-search from the previously found ID if the search failed due to a CRC check to avoid uneven sampling of sensors.
